### PR TITLE
Remove_unwanted_param_from_on_target_workflow

### DIFF
--- a/.github/workflows/on_target.yml
+++ b/.github/workflows/on_target.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build firmware
         working-directory: thingy91x-oob
         run: |
-          west build -b thingy91x/nrf9151/ns app -p -- -DCONFIG_NRF_CLOUD_CLIENT_ID_PREFIX=\"oob-\" -DCONFIG_NRF_CLOUD_SEC_TAG=4242
+          west build -b thingy91x/nrf9151/ns app -p
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The CONFIG_NRF_CLOUD_CLIENT_ID_PREFIX and DCONFIG_NRF_CLOUD_SEC_TAG are
now by default set in the app's prj.conf. Hence this is not necessary
when invoking twister.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>