### PR TITLE
worfklow: sonarcloud: Make it trigger only for c and h files changes

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
   pull_request_target:
+    paths:
+      - '**/*.c'
+      - '**/*.h'
 jobs:
   build:
     name: Build and analyze


### PR DESCRIPTION
Sonarcloud will now be triggered only for changes in .c and .h files.